### PR TITLE
Use `as error` form of the exception for Python3 compatibility.

### DIFF
--- a/oauth_tokens/models.py
+++ b/oauth_tokens/models.py
@@ -157,7 +157,7 @@ class AccessTokenManager(models.Manager):
 
             try:
                 token = self.get_token_of_class(token_class, user).get()
-            except (TokenRequestDenied, AccountLocked, LoginPasswordError, WrongAuthorizationResponseUrl), e:
+            except (TokenRequestDenied, AccountLocked, LoginPasswordError, WrongAuthorizationResponseUrl) as e:
                 log.error(u"Error '%s' while getting new token for provider %s and user %s" % (e, provider, user))
                 user.inactivate(e)
                 continue


### PR DESCRIPTION
Using `except (TokenRequestDenied, AccountLocked, LoginPasswordError, WrongAuthorizationResponseUrl) as e:` instead of `except (TokenRequestDenied, AccountLocked, LoginPasswordError, WrongAuthorizationResponseUrl), e:` makes the library usable for python3.